### PR TITLE
Update README to say the submitter behavior is Safari specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ However, once `FormData.entries` is widely supported this package should be cons
 This module makes a best effort to match the behavior of native `FormData.entries`. It should be possible in the future to replace calls to `formDataEntries(form)` with `new FormData(form).entries()`. However, there are some cases where this module can not fully match the native behavior.
 
 - If the form contains any `<input type=file>` elements, the behavior is considered undefined and should not be relied upon.
-- When called on form submit event, the ponyfill will not include the [`submitter`](https://html.spec.whatwg.org/#constructing-form-data-set) value. There is no way to do this reliably because [the `submitter` element is not exposed](https://github.com/whatwg/html/issues/3195).
+- In Safari when `FormData` is constructed on the submit event, it will include the [`submitter`](https://html.spec.whatwg.org/#constructing-form-data-set) value. This behavior does not exist in other browsers, and is not and can not be implemented in the ponyfill since [the `submitter` element is not exposed](https://github.com/whatwg/html/issues/3195).
 
 ## Test Suite
 


### PR DESCRIPTION
🤷‍♀ 


Safari:

![GIF showing submitter value is reflected after clicking on submit button](https://cl.ly/3c9f0b35c69e/Screen%252520Recording%2525202019-09-23%252520at%25252011.44.gif)

Firefox/Chrome/Edge:

![GIF showing submitter value is not reflected after clicking on submit button](https://cl.ly/7c58e1c5cd2d/Screen%252520Recording%2525202019-09-23%252520at%25252011.44.gif)